### PR TITLE
Fix duplicate export default in TripPlanningPage

### DIFF
--- a/front-end/src/pages/TripPlanningPage.js
+++ b/front-end/src/pages/TripPlanningPage.js
@@ -3,10 +3,8 @@ import TripCard from "../components/TripCard";
 import TripForm from "../components/TripForm";
 import { useTrips } from "../context/TripContext";
 
-export default function TripPlanningPage() {
-  const { trips, loading, error, createTrip, updateTrip, deleteTrip } = useTrips();
 export default function TripPlanningPage({ initialTripId }) {
-  const { trips, addTrip, deleteTrip } = useTrips();
+  const { trips, loading, error, createTrip, updateTrip, deleteTrip } = useTrips();
   const [isOpen, setIsOpen] = useState(false); // controls TripForm modal (create/edit)
   const [selected, setSelected] = useState(null); // holds the trip for view/edit
   const [busy, setBusy] = useState(false);


### PR DESCRIPTION
- Removed duplicate export default function declarations
- Kept the version that accepts initialTripId parameter
- Fixed useTrips destructuring to match actual usage (createTrip, updateTrip, deleteTrip)
- Resolves syntax error: 'import' and 'export' may only appear at the top level